### PR TITLE
Remove order of versions in versions list.

### DIFF
--- a/templates/cakephp/config.neon
+++ b/templates/cakephp/config.neon
@@ -54,5 +54,5 @@ templates:
 			template: robots.txt.latte
 
 options:
-	versions: [1.2, 1.3, '2.0', 2.1, 2.2, 2.3, 2.4, 2.5, '3.0']
+	versions: ['3.0', 2.5, 2.4, 2.3, 2.2, 2.1, '2.0', 1.3, 1.2]
 	activeVersion: '3.0'


### PR DESCRIPTION
This allows newer versions to be at the top for version selection menu.
