### PR TITLE
Don't list core PHP classes in api docs.

### DIFF
--- a/apigen.neon
+++ b/apigen.neon
@@ -57,7 +57,7 @@ accessLevels: [public, protected]
 internal: No
 
 # Generate documentation for PHP internal classes
-php: Yes
+php: No
 
 # Generate tree view of classes, interfaces and exceptions
 tree: Yes


### PR DESCRIPTION
It makes searching difficult. Eg. Trying to search for "datetime" fills the
autocompletion list with DateTime class functions instead of showing CakePHP's
methods like Validation::datetime().
