### PR TITLE
add missing api and book links for 2.6 and 3.0 versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DIR='./build/api'
 .PHONY: build-all
 
 # Versions that can be built.
-VERSIONS = 1.2 1.3 2.0 2.1 2.2 2.3 2.4 2.5 3.0
+VERSIONS = 1.2 1.3 2.0 2.1 2.2 2.3 2.4 2.5 2.6 3.0
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ following versions can be built:
 * 2.3
 * 2.4
 * 2.5
+* 2.6
 * 3.0
 
 By default the api-docs assume that `../cakephp` is a git clone of CakePHP.

--- a/templates/cakephp/config.neon
+++ b/templates/cakephp/config.neon
@@ -54,5 +54,5 @@ templates:
 			template: robots.txt.latte
 
 options:
-	versions: ['3.0', 2.5, 2.4, 2.3, 2.2, 2.1, '2.0', 1.3, 1.2]
+	versions: ['3.0', 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, '2.0', 1.3, 1.2]
 	activeVersion: '3.0'

--- a/templates/cakephp/csf-navbar.latte
+++ b/templates/cakephp/csf-navbar.latte
@@ -14,6 +14,9 @@ CSF navbar element.
 			<ul class="second-level">
 				<li class="cake-version"><a href="http://api.cakephp.org">API</a>
 					<ul class="third-level">
+						<li><a href="http://api.cakephp.org/3.0">3.x</a>&nbsp;|</li>
+						<li><a href="http://api.cakephp.org/2.6">2.6</a>&nbsp;|</li>
+						<li><a href="http://api.cakephp.org/2.5">2.5</a>&nbsp;|</li>
 						<li><a href="http://api.cakephp.org/2.4">2.4</a>&nbsp;|</li>
 						<li><a href="http://api.cakephp.org/2.3">2.3</a>&nbsp;|</li>
 						<li><a href="http://api.cakephp.org/2.2">2.2</a>&nbsp;|</li>
@@ -24,6 +27,7 @@ CSF navbar element.
 				</li>
 				<li class="cake-version"><a href="http://book.cakephp.org">Book</a>
 					<ul class="third-level">
+						<li><a href="http://book.cakephp.org/3.0/en/">3.x</a>&nbsp;|</li>
 						<li><a href="http://book.cakephp.org/2.0/en/">2.x</a>&nbsp;|</li>
 						<li><a href="http://book.cakephp.org/1.3/en/">1.3</a>&nbsp;|</li>
 						<li><a href="http://book.cakephp.org/1.2/en/">1.2</a>&nbsp;|</li>


### PR DESCRIPTION
Will the 2.6 api be built just by adding the 2.6 reference in Makefile or do I need to add something else ?