### PR TITLE
Added option to build only active and missing versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SOURCE_DIR='../cakephp'
-BUILD_DIR='./build/api'
+BUILD_DIR=./build/api
 
 .PHONY: clean
 .PHONY: build-all
@@ -80,6 +80,14 @@ build-all: $(foreach version, $(VERSIONS), build-$(version))
 
 # Build all active versions in a loop.
 build-active: $(foreach version, $(ACTIVE_VERSIONS), build-$(version))
+
+# Build all active and missing versions in a loop.
+build-active-and-missing:
+	for version in $(VERSIONS); do \
+		if [[ "$(ACTIVE_VERSIONS)" =~ "$$version" || ! -d "$(BUILD_DIR)/$$version" ]]; then \
+			$(MAKE) build-$$version; \
+		fi \
+	done
 
 # Generate build targets for various 2.x versions.
 TAG:=2.0.6

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BUILD_DIR=./build/api
 
 .PHONY: clean
 .PHONY: build-all
+.PHONY: build-active-and-missing
 
 # Versions that can be built.
 VERSIONS = 1.2 1.3 2.0 2.1 2.2 2.3 2.4 2.5 2.6 3.0


### PR DESCRIPTION
The goal of this rule is to use on jenkins to optimize resource and speed up the API generation.