### PR TITLE
Add signature & more!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,35 @@
 SOURCE_DIR='../cakephp'
 BUILD_DIR=./build/api
 
-.PHONY: clean
+.PHONY: clean help
 .PHONY: build-all
 .PHONY: build-active-and-missing
+.ALL: help
 
 # Versions that can be built.
 VERSIONS = 1.2 1.3 2.0 2.1 2.2 2.3 2.4 2.5 2.6 3.0
 
 # Versions that are actively developed / maintained.
 ACTIVE_VERSIONS = 2.6 3.0
+
+
+help:
+	@echo "CakePHP API Documentation generator"
+	@echo "-----------------------------------"
+	@echo ""
+	@echo "Tasks:"
+	@echo " clean - Clean the build output directory"
+	@echo ""
+	@echo " build-x.y - Build the x.y documentation. The versions that can be"
+	@echo "             built are:"
+	@echo "             $(VERSIONS)"
+	@echo " build-all - Build all versions of the documentation"
+	@echo " build-active - Build all the actively developed versions: $(ACTIVE_VERSIONS)"
+	@echo ""
+	@echo "Variables:"
+	@echo " SOURCE_DIR - Define where your cakephp clone is. This clone will have its"
+	@echo "              currently checked out branch manipulated. Default: $(SOURCE_DIR)"
+	@echo " BUILD_DIR  - The directory where the output should go. Default: $(BUILD_DIR)"
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/templates/cakephp/class.latte
+++ b/templates/cakephp/class.latte
@@ -271,12 +271,16 @@ the file LICENSE.md that was distributed with this source code.
 		</div>
 	</div>
 
-	<div class="section" n:foreach="$class->inheritedMethods as $parentName => $methods">
-		<h2>Methods inherited from <a href="{$parentName|classUrl}#methods" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
-		<div class="method-detail" n:foreach="$methods as $data">
-			{include #method, method => $data}
+	{foreach $class->inheritedMethods as $parentName => $methods}
+		{if $template->getClass($parentName) && !$template->getClass($parentName)->isInterface()}
+		<div class="section">
+			<h2>Methods inherited from <a href="{$parentName|classUrl}#methods" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
+			<div class="method-detail" n:foreach="$methods as $data">
+				{include #method, method => $data}
+			</div>
 		</div>
-	</div>
+		{/if}
+	{/foreach}
 
 	<div class="section" n:foreach="$class->usedMethods as $traitName => $methods">
 		<h2>Methods used from <a href="{$traitName|classUrl}#methods" n:tag-if="$template->getClass($traitName)">{$traitName}</a></h2>
@@ -379,8 +383,14 @@ the file LICENSE.md that was distributed with this source code.
 	</div>
 
 	{define #property}
-	<tr id="{if $property->magic}m{/if}${$property->name}">
-		<td class="attributes">
+	<div class="property-detail" id="{if $property->magic}m{/if}${$property->name}">
+		{if $class->internal}
+			<a href="{$property|manualUrl}" title="Go to PHP documentation"><var>${$property->name}</var></a>
+		{else}
+			<a n:tag-if="$config->sourceCode" href="{$property|sourceUrl}" title="Go to source code"><var>${$property->name}</var></a>
+		{/if}
+
+		<p class="attributes">
 			{if $property->protected}
 			<span class="label">protected</span>
 			{elseif $property->private}
@@ -397,37 +407,28 @@ the file LICENSE.md that was distributed with this source code.
 			<span class="label">write-only</span>
 			{/if}
 			{!$property->typeHint|typeLinks:$property}
-		</td>
+		</p>
 
-		<td class="name">
-			{if $class->internal}
-				<a href="{$property|manualUrl}" title="Go to PHP documentation"><var>${$property->name}</var></a>
-			{else}
-				<a n:tag-if="$config->sourceCode" href="{$property|sourceUrl}" title="Go to source code"><var>${$property->name}</var></a>
-			{/if}
+		<div class="description detailed">
+			{!$property|longDescription}
 
-			<div class="description detailed">
-				{!$property|longDescription}
-
-				{foreach $template->annotationSort($template->annotationFilter($property->annotations, array('var'))) as $annotation => $descriptions}
-					<h6>{$annotation|annotationBeautify}</h6>
-					<div class="list">
-					{foreach $descriptions as $description}
-						{if $description}
-							{!$description|annotation:$annotation:$property}<br>
-						{/if}
-					{/foreach}
-					</div>
+			{foreach $template->annotationSort($template->annotationFilter($property->annotations, array('var'))) as $annotation => $descriptions}
+				<h6>{$annotation|annotationBeautify}</h6>
+				<div class="list">
+				{foreach $descriptions as $description}
+					{if $description}
+						{!$description|annotation:$annotation:$property}<br>
+					{/if}
 				{/foreach}
-
-				<div n:if="!$property->magic && $property->defaultValueDefinition" class="default-value">
-					<pre>{!$property->defaultValueDefinition|highlightValue:$class}</pre>
 				</div>
+			{/foreach}
+
+			<div n:if="!$property->magic && $property->defaultValueDefinition" class="default-value">
+				<pre>{!$property->defaultValueDefinition|highlightValue:$class}</pre>
 			</div>
+		</div>
 
-		</td>
-
-	</tr>
+	</div>
 	{/define}
 
 	{var $ownProperties = $class->ownProperties}
@@ -448,63 +449,48 @@ the file LICENSE.md that was distributed with this source code.
 
 	<div class="section" n:foreach="$class->inheritedProperties as $parentName => $properties">
 		<h2>Properties inherited from <a href="{$parentName|classUrl}#properties" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
-		<table class="summary inherited">
-		<tr>
-			<td><code>
-			{foreach $properties as $property}
-				<a href="{$property|propertyUrl}" n:tag-if="$template->getClass($parentName)"><var><span n:tag-if="$property->deprecated" class="deprecated">${$property->name}</span></var></a>{sep}, {/sep}
-			{/foreach}
-			</code></td>
-		</tr>
-		</table>
+		<div class="summary properties inherited">
+		{foreach $properties as $property}
+			{include #property, property => $property}
+		{/foreach}
+		</div>
 	</div>
 
 	<div class="section" n:foreach="$class->usedProperties as $traitName => $properties">
 		<h2>Properties used from <a href="{$traitName|classUrl}#properties" n:tag-if="$template->getClass($traitName)">{$traitName}</a></h2>
-		<table n:foreach="$class->usedProperties as $traitName => $properties" class="summary used">
-		<tr>
-			<td><code>
-			{foreach $properties as $property}
-				<a href="{$property|propertyUrl:$property->declaringTrait}" n:tag-if="$template->getClass($traitName)"><var><span n:tag-if="$property->deprecated" class="deprecated">${$property->name}</span></var></a>{sep}, {/sep}
-			{/foreach}
-			</code></td>
-		</tr>
-		</table>
+		<div class="properties summary used">
+		{foreach $properties as $property}
+			{include #property, property => $property}
+		{/foreach}
+		</div>
 	</div>
 
 	<div class="section" n:if="$ownMagicProperties">
 		<h2>Magic properties summary</h2>
-		<table class="summary properties" id="magicProperties">
+		<div class="summary properties" id="magicProperties">
 		{foreach $ownMagicProperties as $property}
 			{include #property, property => $property}
 		{/foreach}
-		</table>
+		</div>
 	</div>
 
 	<div class="section" n:foreach="$class->inheritedMagicProperties as $parentName => $properties">
 		<h2>Magic properties inherited from <a href="{$parentName|classUrl}#properties" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
-		<table class="summary inherited">
-		<tr>
-			<td><code>
-			{foreach $properties as $property}
-				<a href="{$property|propertyUrl}" n:tag-if="$template->getClass($parentName)"><var><span n:tag-if="$property->deprecated" class="deprecated">${$property->name}</span></var></a>{sep}, {/sep}
-			{/foreach}
-			</code></td>
-		</tr>
-		</table>
+		<div class="summary properties inherited">
+		{foreach $properties as $property}
+			{include #property, property => $property}
+		{/foreach}
+		</div>
 	</div>
 
 	<div class="section" n:foreach="$class->usedMagicProperties as $traitName => $properties">
 		<h2>Magic properties used from <a href="{$traitName|classUrl}#properties" n:tag-if="$template->getClass($traitName)">{$traitName}</a></h2>
-		<table class="summary used">
-		<tr>
-			<td><code>
-			{foreach $properties as $property}
-				<a href="{$property|propertyUrl:$property->declaringTrait}" n:tag-if="$template->getClass($traitName)"><var><span n:tag-if="$property->deprecated" class="deprecated">${$property->name}</span></var></a>{sep}, {/sep}
-			{/foreach}
-			</code></td>
-		</tr>
-		</table>
+
+		<div class="summary properities used">
+		{foreach $properties as $property}
+			{include #property, property => $property}
+		{/foreach}
+		</div>
 	</div>
 
 	{else}

--- a/templates/cakephp/class.latte
+++ b/templates/cakephp/class.latte
@@ -140,6 +140,20 @@ the file LICENSE.md that was distributed with this source code.
 			{include #method_signature, method => $method}
 			{include #method_visibility, method => $method}
 		</h3>
+		<p class="method-signature">
+			{block|strip}
+				{$method->name}(
+				{foreach $method->parameters as $parameter}
+					{!$parameter->typeHint|typeLinks:$method}
+						<var>${$parameter->name}</var>
+					{if $parameter->defaultValueAvailable}
+						{!$parameter->defaultValueDefinition|highlightPHP:$class}
+					{/if}
+					{if $parameter->unlimited},…{/if}
+				{/foreach}
+				)
+			{/block}
+		</p>
 
 		<div class="description detailed">
 			{!$method|longDescription}

--- a/templates/cakephp/class.latte
+++ b/templates/cakephp/class.latte
@@ -273,30 +273,16 @@ the file LICENSE.md that was distributed with this source code.
 
 	<div class="section" n:foreach="$class->inheritedMethods as $parentName => $methods">
 		<h2>Methods inherited from <a href="{$parentName|classUrl}#methods" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
-		<table class="summary inherited">
-		<tr>
-			<td><code>
-			{foreach $methods as $method}
-				<a href="{$method|methodUrl}" n:tag-if="$template->getClass($parentName)"><span n:tag-if="$method->deprecated" class="deprecated">{$method->name}()</span></a>{sep}, {/sep}
-			{/foreach}
-			</code></td>
-		</tr>
-		</table>
+		<div class="method-detail" n:foreach="$methods as $data">
+			{include #method, method => $data}
+		</div>
 	</div>
 
 	<div class="section" n:foreach="$class->usedMethods as $traitName => $methods">
 		<h2>Methods used from <a href="{$traitName|classUrl}#methods" n:tag-if="$template->getClass($traitName)">{$traitName}</a></h2>
-		<table class="summary used">
-		<tr>
-			<td><code>
-			{foreach $methods as $data}
-				<a href="{$data['method']|methodUrl:$data['method']->declaringTrait}" n:tag-if="$template->getClass($traitName)">
-				<span n:tag-if="$data['method']->deprecated" class="deprecated">
-					{$data['method']->name}()</span></a>{if $data['aliases']} (as {foreach $data['aliases'] as $alias}<span n:tag-if="$data['method']->deprecated" class="deprecated">{$alias->name}()</span>{sep}, {/sep}{/foreach}){/if}{sep}, {/sep}
-			{/foreach}
-			</code></td>
-		</tr>
-		</table>
+		<div class="method-detail" n:foreach="$methods as $data">
+			{include #method, method => $data['method']}
+		</div>
 	</div>
 
 	<div class="section" n:if="$ownMagicMethods">

--- a/templates/cakephp/class.latte
+++ b/templates/cakephp/class.latte
@@ -124,11 +124,11 @@ the file LICENSE.md that was distributed with this source code.
 	{define #method_signature}
 	{block|strip}
 		{if $class->internal}
-			<a href="{$method|manualUrl}" title="Go to PHP documentation">{$method->name}</a>(
+			<a href="{$method|manualUrl}" title="Go to PHP documentation">{$method->name}</a>
 		{else}
-			<a n:tag-if="$config->sourceCode" href="{$method|sourceUrl}" title="Go to source code">{$method->name}</a>(
+			<a n:tag-if="$config->sourceCode" href="{$method|sourceUrl}" title="Go to source code">{$method->name}</a>
 		{/if}
-	){/block}
+	{/block}
 	{/define}
 
 	{define #method}

--- a/templates/cakephp/css/style.css
+++ b/templates/cakephp/css/style.css
@@ -223,6 +223,9 @@ ul.breadcrumbs li.unavailable a:focus {
 .hidden {
 	display: none;
 }
+.method-signature {
+	font-family: monospace;
+}
 
 /* Menu */
 #menu {

--- a/templates/cakephp/css/style.css
+++ b/templates/cakephp/css/style.css
@@ -372,6 +372,7 @@ ul.breadcrumbs li.unavailable a:focus {
 	padding: 5px 15px;
 }
 
+.method-signature,
 .description pre {
 	padding: .6em;
 	margin-bottom: 18px;

--- a/templates/cakephp/css/style.css
+++ b/templates/cakephp/css/style.css
@@ -183,13 +183,19 @@ ul.breadcrumbs li.unavailable a:focus {
 /**
  * API docs content
  */
+.property-detail,
 .method-detail {
 	padding-bottom: 18px;
 	border-bottom: 1px solid #ddd;
 	margin-bottom: 18px;
 }
+.property-detail:last-child,
 .method-detail:last-child {
 	border-bottom: none;
+}
+
+.property-detail p:last-child {
+	margin-bottom: 0;
 }
 
 .method-name code,
@@ -210,6 +216,9 @@ ul.breadcrumbs li.unavailable a:focus {
 	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.2);
 	display: inline-block;
 	font-family: Helvetica, Arial;
+}
+.label:first-child {
+	margin-left: 0;
 }
 
 .deprecated {

--- a/templates/cakephp/function.latte
+++ b/templates/cakephp/function.latte
@@ -42,7 +42,7 @@ the file LICENSE.md that was distributed with this source code.
 				{!$parameter->typeHint|typeLinks:$function}
 					<var>${$parameter->name}</var>
 				{if $parameter->defaultValueAvailable}
-					{!$parameter->defaultValueDefinition|highlightPHP:$class}
+					{!$parameter->defaultValueDefinition|highlightPHP:$function}
 				{/if}
 				{if $parameter->unlimited},…{/if}
 			{/foreach}

--- a/templates/cakephp/function.latte
+++ b/templates/cakephp/function.latte
@@ -35,6 +35,21 @@ the file LICENSE.md that was distributed with this source code.
 		<b>Located at</b> <a n:tag-if="$config->sourceCode" href="{$function|sourceUrl}" title="Go to source code">{$function->fileName|relativePath}</a><br>
 	</div>
 
+	<p class="method-signature">
+		{block|strip}
+			{$function->name}(
+			{foreach $function->parameters as $parameter}
+				{!$parameter->typeHint|typeLinks:$function}
+					<var>${$parameter->name}</var>
+				{if $parameter->defaultValueAvailable}
+					{!$parameter->defaultValueDefinition|highlightPHP:$class}
+				{/if}
+				{if $parameter->unlimited},…{/if}
+			{/foreach}
+			)
+		{/block}
+	</p>
+
 	{var $annotations = $function->annotations}
 
 	<div class="section" n:if="$function->numberOfParameters">
@@ -51,7 +66,7 @@ the file LICENSE.md that was distributed with this source code.
 	</div>
 
 	<div class="section" n:if="isset($annotations['return']) && 'void' !== $annotations['return'][0]">
-		<h3>Return value summary</h3>
+		<h3>Returns</h3>
 		<ul>
 			<li>
 				<span class="name"><code>
@@ -65,7 +80,7 @@ the file LICENSE.md that was distributed with this source code.
 	</div>
 
 	<div class="section" n:ifset="$annotations['throws']">
-		<h3>Thrown exceptions summary</h3>
+		<h3>Throws</h3>
 		<ul>
 			<li n:foreach="$annotations['throws'] as $throws">
 				<span class="name"><code>


### PR DESCRIPTION
After talking with some of the Loadsys folks at CakeFest, they mentioned that it would be useful to have method signatures in the API docs. I've added that. In addition, these changes

* Make the makefile more helpful.
* Add _actual_ docs to methods inherited from parent classes, and traits. Previously the docs just had hard to use lists of links. Now the actual docs are shown. Interfaces are omitted as the methods the provide are documented in the implementations.
* Tweaked the layout of property docs to be less ugly.

![screen shot 2015-06-02 at 22 38 32](https://cloud.githubusercontent.com/assets/24086/7951648/2fbbf9d0-0978-11e5-9453-cb9fec8d57a5.png)
