### PR TITLE
fixed second level navigation for documentation

### DIFF
--- a/templates/cakephp/css/csf-navbar.css
+++ b/templates/cakephp/css/csf-navbar.css
@@ -116,6 +116,8 @@
 	width: 196px;
 	padding: 2px;
 	margin: 0;
+	height: auto;
+	overflow: hidden;
 }
 /* display on hover */
 #cakephp-global-navigation li:hover .second-level {


### PR DESCRIPTION
added 
- `height: auto`
- `overflow: hidden`