### PR TITLE
Avoid 404 when click on logo

### DIFF
--- a/templates/cakephp/header.latte
+++ b/templates/cakephp/header.latte
@@ -3,7 +3,7 @@
 	<div class="container-fluid hidden-xs hidden-sm">
 		<div class="row">
 			<div class="col-sm-3 col-md-3">
-				<a class="logo-cake" href="/index.html">
+				<a class="logo-cake" href="/">
 					{var logoImg = 'resources/logo-cake.png'}
 					<img alt="CakePHP" src="{$logoImg|staticFile}">
 				</a>


### PR DESCRIPTION
The API page has a broken link on the header. 
When I click on CakePHP's logo, it shouldn't go to 404 page (`http://api.cakephp.org/index.html`).
[![https://gyazo.com/def2f0f2d011e896bb6975edaa14963a](https://i.gyazo.com/def2f0f2d011e896bb6975edaa14963a.png)](https://gyazo.com/def2f0f2d011e896bb6975edaa14963a)

It should be `http://api.cakephp.org/` (according to your `nginx.conf`).