### PR TITLE
Add Property Summary and fold inherited properties

### DIFF
--- a/templates/cakephp/class.latte
+++ b/templates/cakephp/class.latte
@@ -148,58 +148,40 @@ the file LICENSE.md that was distributed with this source code.
 		</ul>
 	</div>
 
-
-	{define #property}
-	<li class="property-detail">
-		<a id="{if $property->magic}m{/if}${$property->name}"></a>
-
-		<div class="property-name col-md-12">
-			{if $class->internal}
-				<a href="{$property|manualUrl}" title="Go to PHP documentation"><var>${$property->name}</var></a>
-			{else}
-				<a n:tag-if="$config->sourceCode" href="{$property|sourceUrl}" title="Go to source code"><var>${$property->name}</var></a>
-				<a href="#{if $property->magic}m{/if}${$property->name}" class="permalink" title="Permalink to this property">¶</a>
-			{/if}
-		</div>
-
-		<div class="attributes col-md-12">
-			{if $property->protected}
-			<span class="label">protected</span>
-			{elseif $property->private}
-			<span class="label">private</span>
-			{else}
-			<span class="label">public</span>
-			{/if}
-			{if $property->static}
-			<span class="label">static</span>
-			{/if}
-			{if $property->readOnly}
-			<span class="label">read-only</span>
-			{elseif $property->writeOnly}
-			<span class="label">write-only</span>
-			{/if}
-			{!$property->typeHint|typeLinks:$property}
-		</div>
-
-		<div class="description detailed col-md-12">
-			{!$property|longDescription}
-
-			{foreach $template->annotationSort($template->annotationFilter($property->annotations, array('var'))) as $annotation => $descriptions}
-				<h6>{$annotation|annotationBeautify}</h6>
-				<div class="list">
-				{foreach $descriptions as $description}
-					{if $description}
-						{!$description|annotation:$annotation:$property}<br>
-					{/if}
-				{/foreach}
-				</div>
-			{/foreach}
-
-			<div n:if="!$property->magic && $property->defaultValueDefinition" class="col-md-10 col-md-offset-2">
-				<pre>{!$property->defaultValueDefinition|highlightValue:$class}</pre>
+	{define #property_summary}
+		<li class="clearfix">
+			<div class="col-md-2 col-sm-2 p0">
+				{!$property->typeHint|typeLinks:$property}
 			</div>
-		</div>
-	</li>
+
+			<div class="name col-md-10 col-sm-10 p0">
+				{if $class->internal}
+					<code><a href="{$property|manualUrl}" title="Go to PHP documentation">${$property->name}</a></code>
+				{else}
+					<code><a n:tag-if="$config->sourceCode" href="{$property|propertyUrl}">${$property->name}</a></code>
+				{/if}
+
+				<span class="attributes">
+					{if $property->protected}
+					<span class="label">protected</span>
+					{elseif $property->private}
+					<span class="label">private</span>
+					{else}
+					<span class="label">public</span>
+					{/if}
+
+					{if $property->static}
+					<span class="label">static</span>
+					{/if}
+
+				</span>
+			</div>
+
+			<div class="col-md-10 col-md-offset-2 description">
+				{!$property|shortDescription}
+			</div>
+
+		</li>
 	{/define}
 
 	{var $ownProperties = $class->ownProperties}
@@ -213,39 +195,7 @@ the file LICENSE.md that was distributed with this source code.
 		<h2>Properties summary</h2>
 		<ul class="member-summary properties">
 		{foreach $ownProperties as $property}
-			<li class="clearfix">
-				<div class="col-md-2 col-sm-2 p0">
-					{!$property->typeHint|typeLinks:$property}
-				</div>
-
-				<div class="name col-md-10 col-sm-10 p0">
-					{if $class->internal}
-						<code><a href="{$property|manualUrl}" title="Go to PHP documentation">${$property->name}</a></code>
-					{else}
-						<code><a n:tag-if="$config->sourceCode" href="{$property|propertyUrl}">${$property->name}</a></code>
-					{/if}
-
-					<span class="attributes">
-						{if $property->protected}
-						<span class="label">protected</span>
-						{elseif $property->private}
-						<span class="label">private</span>
-						{else}
-						<span class="label">public</span>
-						{/if}
-
-						{if $property->static}
-						<span class="label">static</span>
-						{/if}
-
-					</span>
-				</div>
-
-				<div class="col-md-10 col-md-offset-2 description">
-					{!$property|shortDescription}
-				</div>
-
-			</li>
+			{include #property_summary, property => $property}
 		{/foreach}
 		</ul>
 	</div>
@@ -254,7 +204,7 @@ the file LICENSE.md that was distributed with this source code.
 		<h2>Magic properties summary</h2>
 		<ul class="member-summary properties">
 		{foreach $ownMagicProperties as $property}
-			{include #property, property => $property}
+			{include #property_summary, property => $property}
 		{/foreach}
 		</ul>
 	</div>
@@ -518,6 +468,79 @@ the file LICENSE.md that was distributed with this source code.
 			</code></td>
 		</tr>
 		</table>
+	</div>
+
+	{define #property}
+	<div class="property-detail">
+		<a id="{if $property->magic}m{/if}${$property->name}"></a>
+
+		<h3 class="property-name">
+			{if $class->internal}
+				<a href="{$property|manualUrl}" title="Go to PHP documentation"><var>${$property->name}</var></a>
+			{else}
+				<a n:tag-if="$config->sourceCode" href="{$property|sourceUrl}" title="Go to source code"><var>${$property->name}</var></a>
+				<a href="#{if $property->magic}m{/if}${$property->name}" class="permalink" title="Permalink to this property">¶</a>
+			{/if}
+		</h3>
+
+		<div class="attributes">
+			{if $property->protected}
+			<span class="label">protected</span>
+			{elseif $property->private}
+			<span class="label">private</span>
+			{else}
+			<span class="label">public</span>
+			{/if}
+			{if $property->static}
+			<span class="label">static</span>
+			{/if}
+			{if $property->readOnly}
+			<span class="label">read-only</span>
+			{elseif $property->writeOnly}
+			<span class="label">write-only</span>
+			{/if}
+			{!$property->typeHint|typeLinks:$property}
+		</div>
+
+		<div class="description detailed">
+			{!$property|longDescription}
+
+			{foreach $template->annotationSort($template->annotationFilter($property->annotations, array('var'))) as $annotation => $descriptions}
+				<h6>{$annotation|annotationBeautify}</h6>
+				<div class="list">
+				{foreach $descriptions as $description}
+					{if $description}
+						{!$description|annotation:$annotation:$property}<br>
+					{/if}
+				{/foreach}
+				</div>
+			{/foreach}
+
+			<div n:if="!$property->magic && $property->defaultValueDefinition">
+				<pre>{!$property->defaultValueDefinition|highlightValue:$class}</pre>
+			</div>
+		</div>
+	</div>
+	{/define}
+
+	{var $ownProperties = $class->ownProperties}
+	{var $ownMagicProperties = $class->ownMagicProperties}
+	<?php
+	ksort($ownProperties);
+	ksort($ownMagicProperties);
+	?>
+	<div class="section" n:if="$ownProperties">
+		<h2>Properties detail</h2>
+		{foreach $ownProperties as $property}
+			{include #property, property => $property}
+		{/foreach}
+	</div>
+
+	<div class="section" n:if="$ownMagicProperties">
+		<h2>Magic properties detail</h2>
+		{foreach $ownMagicProperties as $property}
+			{include #property, property => $property}
+		{/foreach}
 	</div>
 
 	{else}

--- a/templates/cakephp/class.latte
+++ b/templates/cakephp/class.latte
@@ -150,17 +150,19 @@ the file LICENSE.md that was distributed with this source code.
 
 
 	{define #property}
-	<div class="property-detail" id="{if $property->magic}m{/if}${$property->name}">
-		{if $class->internal}
-			<a href="{$property|manualUrl}" title="Go to PHP documentation"><var>${$property->name}</var></a>
-		{else}
-			<div class="property-name">
+	<li class="property-detail">
+		<a id="{if $property->magic}m{/if}${$property->name}"></a>
+
+		<div class="property-name col-md-12">
+			{if $class->internal}
+				<a href="{$property|manualUrl}" title="Go to PHP documentation"><var>${$property->name}</var></a>
+			{else}
 				<a n:tag-if="$config->sourceCode" href="{$property|sourceUrl}" title="Go to source code"><var>${$property->name}</var></a>
 				<a href="#{if $property->magic}m{/if}${$property->name}" class="permalink" title="Permalink to this property">¶</a>
-			</div>
-		{/if}
+			{/if}
+		</div>
 
-		<p class="attributes">
+		<div class="attributes col-md-12">
 			{if $property->protected}
 			<span class="label">protected</span>
 			{elseif $property->private}
@@ -177,9 +179,9 @@ the file LICENSE.md that was distributed with this source code.
 			<span class="label">write-only</span>
 			{/if}
 			{!$property->typeHint|typeLinks:$property}
-		</p>
+		</div>
 
-		<div class="description detailed">
+		<div class="description detailed col-md-12">
 			{!$property|longDescription}
 
 			{foreach $template->annotationSort($template->annotationFilter($property->annotations, array('var'))) as $annotation => $descriptions}
@@ -193,12 +195,11 @@ the file LICENSE.md that was distributed with this source code.
 				</div>
 			{/foreach}
 
-			<div n:if="!$property->magic && $property->defaultValueDefinition" class="default-value">
+			<div n:if="!$property->magic && $property->defaultValueDefinition" class="col-md-10 col-md-offset-2">
 				<pre>{!$property->defaultValueDefinition|highlightValue:$class}</pre>
 			</div>
 		</div>
-
-	</div>
+	</li>
 	{/define}
 
 	{var $ownProperties = $class->ownProperties}
@@ -210,20 +211,52 @@ the file LICENSE.md that was distributed with this source code.
 
 	<div class="section" n:if="$ownProperties">
 		<h2>Properties summary</h2>
-		<table class="summary properties" id="properties">
+		<ul class="member-summary properties">
 		{foreach $ownProperties as $property}
-			{include #property, property => $property}
+			<li class="clearfix">
+				<div class="col-md-2 col-sm-2 p0">
+					{!$property->typeHint|typeLinks:$property}
+				</div>
+
+				<div class="name col-md-10 col-sm-10 p0">
+					{if $class->internal}
+						<code><a href="{$property|manualUrl}" title="Go to PHP documentation">${$property->name}</a></code>
+					{else}
+						<code><a n:tag-if="$config->sourceCode" href="{$property|propertyUrl}">${$property->name}</a></code>
+					{/if}
+
+					<span class="attributes">
+						{if $property->protected}
+						<span class="label">protected</span>
+						{elseif $property->private}
+						<span class="label">private</span>
+						{else}
+						<span class="label">public</span>
+						{/if}
+
+						{if $property->static}
+						<span class="label">static</span>
+						{/if}
+
+					</span>
+				</div>
+
+				<div class="col-md-10 col-md-offset-2 description">
+					{!$property|shortDescription}
+				</div>
+
+			</li>
 		{/foreach}
-		</table>
+		</ul>
 	</div>
 
 	<div class="section" n:if="$ownMagicProperties">
 		<h2>Magic properties summary</h2>
-		<div class="summary properties" id="magicProperties">
+		<ul class="member-summary properties">
 		{foreach $ownMagicProperties as $property}
 			{include #property, property => $property}
 		{/foreach}
-		</div>
+		</ul>
 	</div>
 
 	<div class="section" n:foreach="$class->inheritedMagicProperties as $parentName => $properties">

--- a/templates/cakephp/class.latte
+++ b/templates/cakephp/class.latte
@@ -99,6 +99,56 @@ the file LICENSE.md that was distributed with this source code.
 		{if $class->internal}<b>Documented at</b> <a href="{$class|manualUrl}" title="Go to PHP documentation">php.net</a>{else}<b>Location:</b> <a n:tag-if="$config->sourceCode" href="{$class|sourceUrl}" title="Go to source code">{$class->fileName|relativePath}</a>{/if}<br>
 	</div>
 
+	{var $ownConstants = $class->ownConstants}
+	<?php
+	ksort($ownConstants);
+	?>
+	<div class="section" n:if="$ownConstants">
+		<h2>Constants summary</h2>
+		<ul class="member-summary constants">
+		<li n:foreach="$ownConstants as $constant" class="clearfix">
+			<a id="{$constant->name}"></a>
+			{var $annotations = $constant->annotations}
+			<div class="attributes col-md-2 col-sm-2 p0">
+				<code>{!$constant->typeHint|typeLinks:$constant}</code>
+			</div>
+
+			<div class="name col-md-10 col-sm-10">
+				<code>
+				{if $class->internal}
+					<a href="{$constant|manualUrl}" title="Go to PHP documentation"><b>{$constant->name}</b></a>
+				{else}
+					<a n:tag-if="$config->sourceCode" href="{$constant|sourceUrl}" title="Go to source code"><b>{$constant->name}</b></a>
+				{/if}
+				</code>
+				<a href="#{$constant->name}" class="permalink" title="Permalink to this constant">¶</a>
+			</div>
+
+			<p n:if="$config->template->options->elementDetailsCollapsed" class="description short col-md-10 col-md-offset-2">
+				{!$constant|shortDescription:true}
+			</p>
+
+			<div class="col-md-10 col-md-offset-2">
+				<code>{!$constant->valueDefinition|highlightValue:$class}</code>
+			</div>
+		</li>
+		</ul>
+	</div>
+
+	<div class="section" n:foreach="$class->inheritedConstants as $parentName => $constants">
+		<h2>Constants inherited from <a href="{$parentName|classUrl}#constants" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
+		<table class="summary inherited">
+		<tr>
+			<td><code>
+			{foreach $constants as $constant}
+				<a href="{$constant|constantUrl}" n:tag-if="$template->getClass($parentName)"><b><span n:tag-if="$constant->deprecated" class"deprecated">{$constant->name}</span></b></a>{sep}, {/sep}
+			{/foreach}
+			</code></td>
+		</tr>
+		</table>
+	</div>
+
+
 	{var $ownMethods = $class->ownMethods}
 	{var $ownMagicMethods = $class->ownMagicMethods}
 	<?php
@@ -299,64 +349,6 @@ the file LICENSE.md that was distributed with this source code.
 			<td><code>
 			{foreach $methods as $data}
 				<a href="{$data['method']|methodUrl:$data['method']->declaringTrait}" n:tag-if="$template->getClass($traitName)"><span n:tag-if="$data['method']->deprecated" class="deprecated">{$data['method']->originalName}()</span></a>{if $data['aliases']}(as {foreach $data['aliases'] as $alias}<span n:tag-if="$data['method']->deprecated" class="deprecated">{$alias->name}()</span>{sep}, {/sep}{/foreach}){/if}{sep}, {/sep}
-			{/foreach}
-			</code></td>
-		</tr>
-		</table>
-	</div>
-
-	{var $ownConstants = $class->ownConstants}
-	<?php
-	ksort($ownConstants);
-	?>
-
-	<div class="section" n:if="$ownConstants">
-		<h2>Constants summary</h2>
-		<table class="summary constants" id="constants">
-		<tr n:foreach="$ownConstants as $constant" data-order="{$constant->name}" id="{$constant->name}">
-			{var $annotations = $constant->annotations}
-
-			<td class="attributes"><code>{!$constant->typeHint|typeLinks:$constant}</code></td>
-			<td class="name">
-				<code>
-				{if $class->internal}
-					<a href="{$constant|manualUrl}" title="Go to PHP documentation"><b>{$constant->name}</b></a>
-				{else}
-					<a n:tag-if="$config->sourceCode" href="{$constant|sourceUrl}" title="Go to source code"><b>{$constant->name}</b></a>
-				{/if}
-				</code>
-
-				<div n:if="$config->template->options->elementDetailsCollapsed" class="description short">
-					{!$constant|shortDescription:true}
-				</div>
-
-				<div n:class="description, detailed, $config->template->options->elementDetailsCollapsed ? hidden">
-					{!$constant|longDescription}
-
-					{foreach $template->annotationSort($template->annotationFilter($annotations, array('var'))) as $annotation => $descriptions}
-						<h6>{$annotation|annotationBeautify}</h6>
-						<div class="list">
-						{foreach $descriptions as $description}
-							{if $description}
-								{!$description|annotation:$annotation:$constant}<br>
-							{/if}
-						{/foreach}
-						</div>
-					{/foreach}
-				</div>
-			</td>
-			<td class="value"><div><a href="#{$constant->name}" class="anchor">#</a><code>{!$constant->valueDefinition|highlightValue:$class}</code></div></td>
-		</tr>
-		</table>
-	</div>
-
-	<div class="section" n:foreach="$class->inheritedConstants as $parentName => $constants">
-		<h2>Constants inherited from <a href="{$parentName|classUrl}#constants" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
-		<table class="summary inherited">
-		<tr>
-			<td><code>
-			{foreach $constants as $constant}
-				<a href="{$constant|constantUrl}" n:tag-if="$template->getClass($parentName)"><b><span n:tag-if="$constant->deprecated" class"deprecated">{$constant->name}</span></b></a>{sep}, {/sep}
 			{/foreach}
 			</code></td>
 		</tr>

--- a/templates/cakephp/class.latte
+++ b/templates/cakephp/class.latte
@@ -137,16 +137,149 @@ the file LICENSE.md that was distributed with this source code.
 
 	<div class="section" n:foreach="$class->inheritedConstants as $parentName => $constants">
 		<h2>Constants inherited from <a href="{$parentName|classUrl}#constants" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
-		<table class="summary inherited">
-		<tr>
-			<td><code>
+		<ul class="member-summary inherited">
+		<li>
 			{foreach $constants as $constant}
-				<a href="{$constant|constantUrl}" n:tag-if="$template->getClass($parentName)"><b><span n:tag-if="$constant->deprecated" class"deprecated">{$constant->name}</span></b></a>{sep}, {/sep}
+				<code><a href="{$constant|constantUrl}" n:tag-if="$template->getClass($parentName)"><!--
+				--><span n:tag-if="$constant->deprecated" class"deprecated">{$constant->name}</span><!--
+				--></a></code>{sep}, {/sep}
 			{/foreach}
-			</code></td>
-		</tr>
+		</li>
+		</ul>
+	</div>
+
+
+	{define #property}
+	<div class="property-detail" id="{if $property->magic}m{/if}${$property->name}">
+		{if $class->internal}
+			<a href="{$property|manualUrl}" title="Go to PHP documentation"><var>${$property->name}</var></a>
+		{else}
+			<div class="property-name">
+				<a n:tag-if="$config->sourceCode" href="{$property|sourceUrl}" title="Go to source code"><var>${$property->name}</var></a>
+				<a href="#{if $property->magic}m{/if}${$property->name}" class="permalink" title="Permalink to this property">¶</a>
+			</div>
+		{/if}
+
+		<p class="attributes">
+			{if $property->protected}
+			<span class="label">protected</span>
+			{elseif $property->private}
+			<span class="label">private</span>
+			{else}
+			<span class="label">public</span>
+			{/if}
+			{if $property->static}
+			<span class="label">static</span>
+			{/if}
+			{if $property->readOnly}
+			<span class="label">read-only</span>
+			{elseif $property->writeOnly}
+			<span class="label">write-only</span>
+			{/if}
+			{!$property->typeHint|typeLinks:$property}
+		</p>
+
+		<div class="description detailed">
+			{!$property|longDescription}
+
+			{foreach $template->annotationSort($template->annotationFilter($property->annotations, array('var'))) as $annotation => $descriptions}
+				<h6>{$annotation|annotationBeautify}</h6>
+				<div class="list">
+				{foreach $descriptions as $description}
+					{if $description}
+						{!$description|annotation:$annotation:$property}<br>
+					{/if}
+				{/foreach}
+				</div>
+			{/foreach}
+
+			<div n:if="!$property->magic && $property->defaultValueDefinition" class="default-value">
+				<pre>{!$property->defaultValueDefinition|highlightValue:$class}</pre>
+			</div>
+		</div>
+
+	</div>
+	{/define}
+
+	{var $ownProperties = $class->ownProperties}
+	{var $ownMagicProperties = $class->ownMagicProperties}
+	<?php
+	ksort($ownProperties);
+	ksort($ownMagicProperties);
+	?>
+
+	<div class="section" n:if="$ownProperties">
+		<h2>Properties summary</h2>
+		<table class="summary properties" id="properties">
+		{foreach $ownProperties as $property}
+			{include #property, property => $property}
+		{/foreach}
 		</table>
 	</div>
+
+	<div class="section" n:if="$ownMagicProperties">
+		<h2>Magic properties summary</h2>
+		<div class="summary properties" id="magicProperties">
+		{foreach $ownMagicProperties as $property}
+			{include #property, property => $property}
+		{/foreach}
+		</div>
+	</div>
+
+	<div class="section" n:foreach="$class->inheritedMagicProperties as $parentName => $properties">
+		<h2>Magic properties inherited from <a href="{$parentName|classUrl}#properties" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
+		<ul class="member-summary used">
+		<li>
+			{foreach $properties as $property}
+				<code><a href="{$property|propertyUrl}" n:tag-if="$template->getClass($parentName)"><!--
+					--><span n:tag-if="$property->deprecated" class"deprecated">{$property->name}</span><!--
+				--></a></code>{sep}, {/sep}
+			{/foreach}
+		</li>
+		</ul>
+	</div>
+
+	<div class="section" n:foreach="$class->usedMagicProperties as $traitName => $properties">
+		<h2>Magic properties used from <a href="{$traitName|classUrl}#properties" n:tag-if="$template->getClass($traitName)">{$traitName}</a></h2>
+
+		<ul class="member-summary used">
+		<li>
+			{foreach $properties as $property}
+				<code><a href="{$property|propertyUrl}" n:tag-if="$template->getClass($traitName)"><!--
+					--><span n:tag-if="$property->deprecated" class"deprecated">{$property->name}</span><!--
+				--></a></code>{sep}, {/sep}
+			{/foreach}
+		</li>
+		</ul>
+	</div>
+
+	<div class="section" n:foreach="$class->inheritedProperties as $parentName => $properties">
+		<h2>Properties inherited from <a href="{$parentName|classUrl}#properties" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
+		<ul class="member-summary inherited">
+		<li>
+			{foreach $properties as $property}
+				<code><a href="{$property|propertyUrl}" n:tag-if="$template->getClass($parentName)"><!--
+					--><span n:tag-if="$property->deprecated" class"deprecated">{$property->name}</span><!--
+				--></a></code>{sep}, {/sep}
+			{/foreach}
+		</li>
+		</ul>
+	</div>
+
+	<div class="section" n:foreach="$class->usedProperties as $traitName => $properties">
+		<h2>Properties used from <a href="{$traitName|classUrl}#properties" n:tag-if="$template->getClass($traitName)">{$traitName}</a></h2>
+		<ul class="member-summary used">
+		<li>
+			{foreach $properties as $property}
+				<code><a href="{$property|propertyUrl}" n:tag-if="$template->getClass($traitName)"><!--
+					--><span n:tag-if="$property->deprecated" class"deprecated">{$property->name}</span><!--
+				--></a></code>{sep}, {/sep}
+			{/foreach}
+		</li>
+		</ul>
+	</div>
+
+
 
 
 	{var $ownMethods = $class->ownMethods}
@@ -155,7 +288,6 @@ the file LICENSE.md that was distributed with this source code.
 	ksort($ownMethods);
 	ksort($ownMagicMethods);
 	?>
-
 	{define #method_visibility}
 	{var $annotations = $method->annotations}
 		{if !$class->interface && $method->abstract}
@@ -353,120 +485,6 @@ the file LICENSE.md that was distributed with this source code.
 			</code></td>
 		</tr>
 		</table>
-	</div>
-
-	{define #property}
-	<div class="property-detail" id="{if $property->magic}m{/if}${$property->name}">
-		{if $class->internal}
-			<a href="{$property|manualUrl}" title="Go to PHP documentation"><var>${$property->name}</var></a>
-		{else}
-			<div class="property-name">
-				<a n:tag-if="$config->sourceCode" href="{$property|sourceUrl}" title="Go to source code"><var>${$property->name}</var></a>
-				<a href="#{if $property->magic}m{/if}${$property->name}" class="permalink" title="Permalink to this property">¶</a>
-			</div>
-		{/if}
-
-		<p class="attributes">
-			{if $property->protected}
-			<span class="label">protected</span>
-			{elseif $property->private}
-			<span class="label">private</span>
-			{else}
-			<span class="label">public</span>
-			{/if}
-			{if $property->static}
-			<span class="label">static</span>
-			{/if}
-			{if $property->readOnly}
-			<span class="label">read-only</span>
-			{elseif $property->writeOnly}
-			<span class="label">write-only</span>
-			{/if}
-			{!$property->typeHint|typeLinks:$property}
-		</p>
-
-		<div class="description detailed">
-			{!$property|longDescription}
-
-			{foreach $template->annotationSort($template->annotationFilter($property->annotations, array('var'))) as $annotation => $descriptions}
-				<h6>{$annotation|annotationBeautify}</h6>
-				<div class="list">
-				{foreach $descriptions as $description}
-					{if $description}
-						{!$description|annotation:$annotation:$property}<br>
-					{/if}
-				{/foreach}
-				</div>
-			{/foreach}
-
-			<div n:if="!$property->magic && $property->defaultValueDefinition" class="default-value">
-				<pre>{!$property->defaultValueDefinition|highlightValue:$class}</pre>
-			</div>
-		</div>
-
-	</div>
-	{/define}
-
-	{var $ownProperties = $class->ownProperties}
-	{var $ownMagicProperties = $class->ownMagicProperties}
-	<?php
-	ksort($ownProperties);
-	ksort($ownMagicProperties);
-	?>
-
-	<div class="section" n:if="$ownProperties">
-		<h2>Properties summary</h2>
-		<table class="summary properties" id="properties">
-		{foreach $ownProperties as $property}
-			{include #property, property => $property}
-		{/foreach}
-		</table>
-	</div>
-
-	<div class="section" n:foreach="$class->inheritedProperties as $parentName => $properties">
-		<h2>Properties inherited from <a href="{$parentName|classUrl}#properties" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
-		<div class="summary properties inherited">
-		{foreach $properties as $property}
-			{include #property, property => $property}
-		{/foreach}
-		</div>
-	</div>
-
-	<div class="section" n:foreach="$class->usedProperties as $traitName => $properties">
-		<h2>Properties used from <a href="{$traitName|classUrl}#properties" n:tag-if="$template->getClass($traitName)">{$traitName}</a></h2>
-		<div class="properties summary used">
-		{foreach $properties as $property}
-			{include #property, property => $property}
-		{/foreach}
-		</div>
-	</div>
-
-	<div class="section" n:if="$ownMagicProperties">
-		<h2>Magic properties summary</h2>
-		<div class="summary properties" id="magicProperties">
-		{foreach $ownMagicProperties as $property}
-			{include #property, property => $property}
-		{/foreach}
-		</div>
-	</div>
-
-	<div class="section" n:foreach="$class->inheritedMagicProperties as $parentName => $properties">
-		<h2>Magic properties inherited from <a href="{$parentName|classUrl}#properties" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
-		<div class="summary properties inherited">
-		{foreach $properties as $property}
-			{include #property, property => $property}
-		{/foreach}
-		</div>
-	</div>
-
-	<div class="section" n:foreach="$class->usedMagicProperties as $traitName => $properties">
-		<h2>Magic properties used from <a href="{$traitName|classUrl}#properties" n:tag-if="$template->getClass($traitName)">{$traitName}</a></h2>
-
-		<div class="summary properities used">
-		{foreach $properties as $property}
-			{include #property, property => $property}
-		{/foreach}
-		</div>
 	</div>
 
 	{else}

--- a/templates/cakephp/class.latte
+++ b/templates/cakephp/class.latte
@@ -135,14 +135,16 @@ the file LICENSE.md that was distributed with this source code.
 		</ul>
 	</div>
 
-	<div class="section" n:foreach="$class->inheritedConstants as $parentName => $constants">
-		<h2>Constants inherited from <a href="{$parentName|classUrl}#constants" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
+	<div class="section" n:if="$class->inheritedConstants">
+		<h2>Inherited Constants</h2>
 		<ul class="member-summary inherited">
 		<li>
-			{foreach $constants as $constant}
-				<code><a href="{$constant|constantUrl}" n:tag-if="$template->getClass($parentName)"><!--
-				--><span n:tag-if="$constant->deprecated" class"deprecated">{$constant->name}</span><!--
-				--></a></code>{sep}, {/sep}
+			{foreach $class->inheritedConstants as $parentName => $constants}
+				{foreach $constants as $constant}
+					<code><a href="{$constant|constantUrl}" n:tag-if="$template->getClass($parentName)"><!--
+					--><span n:tag-if="$constant->deprecated" class"deprecated">{$constant->name}</span><!--
+					--></a></code>{sep}, {/sep}
+				{/foreach}
 			{/foreach}
 		</li>
 		</ul>
@@ -209,60 +211,41 @@ the file LICENSE.md that was distributed with this source code.
 		</ul>
 	</div>
 
-	<div class="section" n:foreach="$class->inheritedMagicProperties as $parentName => $properties">
-		<h2>Magic properties inherited from <a href="{$parentName|classUrl}#properties" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
+	<?php
+	$inheritedMagicProperties = array_merge($class->inheritedMagicProperties, $class->usedMagicProperties)
+	?>
+	<div class="section" n:if="$inheritedMagicProperties">
+		<h2>Inherited Magic Properties</h2>
 		<ul class="member-summary used">
-		<li>
-			{foreach $properties as $property}
-				<code><a href="{$property|propertyUrl}" n:tag-if="$template->getClass($parentName)"><!--
+			<li>
+			{foreach $inheritedMagicProperties as $parentName => $properties}
+				{foreach $properties as $property}
+					<code><a href="{$property|propertyUrl}" n:tag-if="$template->getClass($parentName)"><!--
 					--><span n:tag-if="$property->deprecated" class"deprecated">{$property->name}</span><!--
-				--></a></code>{sep}, {/sep}
+					--></a></code>{sep}, {/sep}
+				{/foreach}
 			{/foreach}
-		</li>
+			</li>
 		</ul>
 	</div>
 
-	<div class="section" n:foreach="$class->usedMagicProperties as $traitName => $properties">
-		<h2>Magic properties used from <a href="{$traitName|classUrl}#properties" n:tag-if="$template->getClass($traitName)">{$traitName}</a></h2>
-
+	<?php
+	$inheritedProperties = array_merge($class->inheritedProperties, $class->usedProperties)
+	?>
+	<div class="section" n:if="$inheritedProperties">
+		<h2>Inherited Properties</h2>
 		<ul class="member-summary used">
-		<li>
-			{foreach $properties as $property}
-				<code><a href="{$property|propertyUrl}" n:tag-if="$template->getClass($traitName)"><!--
+			<li>
+			{foreach $inheritedProperties as $parentName => $properties}
+				{foreach $properties as $property}
+					<code><a href="{$property|propertyUrl}" n:tag-if="$template->getClass($parentName)"><!--
 					--><span n:tag-if="$property->deprecated" class"deprecated">{$property->name}</span><!--
-				--></a></code>{sep}, {/sep}
+					--></a></code>{sep}, {/sep}
+				{/foreach}
 			{/foreach}
-		</li>
+			</li>
 		</ul>
 	</div>
-
-	<div class="section" n:foreach="$class->inheritedProperties as $parentName => $properties">
-		<h2>Properties inherited from <a href="{$parentName|classUrl}#properties" n:tag-if="$template->getClass($parentName)">{$parentName}</a></h2>
-		<ul class="member-summary inherited">
-		<li>
-			{foreach $properties as $property}
-				<code><a href="{$property|propertyUrl}" n:tag-if="$template->getClass($parentName)"><!--
-					--><span n:tag-if="$property->deprecated" class"deprecated">{$property->name}</span><!--
-				--></a></code>{sep}, {/sep}
-			{/foreach}
-		</li>
-		</ul>
-	</div>
-
-	<div class="section" n:foreach="$class->usedProperties as $traitName => $properties">
-		<h2>Properties used from <a href="{$traitName|classUrl}#properties" n:tag-if="$template->getClass($traitName)">{$traitName}</a></h2>
-		<ul class="member-summary used">
-		<li>
-			{foreach $properties as $property}
-				<code><a href="{$property|propertyUrl}" n:tag-if="$template->getClass($traitName)"><!--
-					--><span n:tag-if="$property->deprecated" class"deprecated">{$property->name}</span><!--
-				--></a></code>{sep}, {/sep}
-			{/foreach}
-		</li>
-		</ul>
-	</div>
-
-
 
 
 	{var $ownMethods = $class->ownMethods}

--- a/templates/cakephp/css/styles.css
+++ b/templates/cakephp/css/styles.css
@@ -2117,7 +2117,7 @@ header {
 
 /* - Constant, property and method summaries. - */
 .member-summary {
-    margin: 0;
+    margin: 0 0 2em 0;
 }
 .member-summary li {
     list-style: none;

--- a/templates/cakephp/css/styles.css
+++ b/templates/cakephp/css/styles.css
@@ -2115,6 +2115,23 @@ header {
 }
 
 
+/* - Constant, property and method summaries. - */
+.member-summary {
+    margin: 0;
+}
+.member-summary li {
+    list-style: none;
+    margin-bottom: 1em;
+    clear: both;
+}
+.member-summary .description {
+    padding: 0;
+}
+.member-summary p:last-child {
+    margin-bottom: 0;
+}
+
+
 /* Property tables */
 .summary .description {
     padding: 0;
@@ -2182,6 +2199,7 @@ pre::-webkit-scrollbar-thumb:horizontal {
     display: none;
 }
 
+.member-summary li:hover .permalink,
 .method-name:hover .permalink,
 .property-name:hover .permalink {
     display: inline;

--- a/templates/cakephp/css/styles.css
+++ b/templates/cakephp/css/styles.css
@@ -2140,15 +2140,13 @@ header {
     margin-bottom: 0;
 }
 
-.summary .name {
-    vertical-align: top;
+/* - Property details - */
+.property-detail {
+    margin-bottom: 3em;
 }
-.summary .attributes {
-    width: 1%;
-    padding: 0 0.5em 0.5em 0.5em;
-    vertical-align: top;
+.property-detail .attributes {
+    margin-bottom: 1em;
 }
-
 
 .class .methods .name,
 .class .properties .name,


### PR DESCRIPTION
This set of changes implements the ideas discussed in #47. I've added property summary, hoisted and cleaned up the property summary & constants. The high-level order is now:

* Constants
* Inherited constants.
* Property Summary
* Inherited Property Summary
* Method Details
* Inherited Method Details
* Property Details.

I'm considering making Inherited Methods a list like other inherited features for consistency, and reducing the duplication in the docs.

### Screenshots

#### Property summary
![screen shot 2016-06-26 at 08 05 29](https://cloud.githubusercontent.com/assets/24086/16362185/6f2e4700-3b75-11e6-8d8c-0500bd86f64c.png)

#### Constants
![screen shot 2016-06-26 at 08 06 12](https://cloud.githubusercontent.com/assets/24086/16362187/7680d248-3b75-11e6-863d-712fd5d38617.png)

#### Property Details
![screen shot 2016-06-26 at 08 05 51](https://cloud.githubusercontent.com/assets/24086/16362189/7d670a14-3b75-11e6-80da-abf22a7c80c3.png)

#### Inherited listing
![screen shot 2016-06-26 at 08 06 06](https://cloud.githubusercontent.com/assets/24086/16362193/88404d56-3b75-11e6-9909-5bf197577753.png)

