### PR TITLE
restore source code line numbers display

### DIFF
--- a/templates/cakephp/source.latte
+++ b/templates/cakephp/source.latte
@@ -15,6 +15,5 @@ the file LICENSE.md that was distributed with this source code.
 
 {block #content}
 {var $lineRegex = '~<span class="line">(\\s*(\\d+):\\s*)</span>([^\\n]*(?:\\n|$))~'}
-<pre class="numbers"><code>{$source|replaceRE:$lineRegex,'<span class="l"><a href="#$2">$1</a></span>'|noescape}</code></pre>
-<pre class="code"><code>{$source|replaceRE:$lineRegex,'<span id="$2" class="l">$3</span>'|noescape}</code></pre>
+<pre><code>{$source|replaceRE:$lineRegex,'<span id="$2" class="l"><a class="l" href="#$2">$1</a>$3</span>'|noescape}</code></pre>
 {/block}


### PR DESCRIPTION
fixes #56

before:
<img width="1253" alt="capture d ecran 2016-07-15 a 16 08 34" src="https://cloud.githubusercontent.com/assets/4977112/16877017/9e588302-4aa6-11e6-95c6-2667774c3003.png">

after:
<img width="1254" alt="capture d ecran 2016-07-15 a 16 08 46" src="https://cloud.githubusercontent.com/assets/4977112/16877026/a5d656c2-4aa6-11e6-8bfc-b92db0b070cd.png">
