### PR TITLE
Fix StringTemplate missing and upgrade apigen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ build-$(VERSION): $(BUILD_DIR) install
 		-s $(SOURCE_DIR)/src \
 		-d $(BUILD_DIR)/$(VERSION) \
 		--title 'CakePHP' \
-		--exclude **\Template\**
+		--exclude **/Template/**
 endef
 
 define build2x
@@ -121,8 +121,8 @@ build-chronos-$(VERSION): $(BUILD_DIR) install
 	vendor/bin/apigen generate -s $(CHRONOS_SOURCE_DIR) \
 		-d $(BUILD_DIR)/chronos/$(VERSION) \
 		--title 'Chronos' \
-		--exclude **\tests\** \
-		--exclude **\vendor\**
+		--exclude **/tests/** \
+		--exclude **/vendor/**
 endef
 
 # Build all the versions in a loop.

--- a/composer.json
+++ b/composer.json
@@ -3,52 +3,6 @@
     "description": "API docs for CakePHP",
     "type": "application",
     "require": {
-        "apigen/apigen": "dev-issue-fix-tree"
-    },
-    "license": "MIT",
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "apigen/apigen",
-                "version": "dev-issue-fix-tree",
-                "dist": {
-                    "url": "https://github.com/markstory/apigen/archive/issue-fix-tree.zip",
-                    "type": "zip"
-                },
-                "source": {
-                    "url": "https://github.com/markstory/apigen",
-                    "type": "git",
-                    "reference": "issue-fix-tree"
-                },
-                "require": {
-                    "php": ">=5.5",
-                    "andrewsville/php-token-reflection": "^1.4",
-                    "apigen/theme-bootstrap": "1.1.*",
-                    "apigen/theme-default": "1.0.*",
-                    "herrera-io/phar-update": "~2.0",
-                    "kukulich/fshl": "~2.1",
-                    "latte/latte": "^2.3.6",
-                    "michelf/php-markdown": "~1.4",
-                    "nette/bootstrap": "^2.3",
-                    "nette/di": "^2.3",
-                    "nette/neon": "^2.3",
-                    "nette/reflection": "^2.3",
-                    "symfony/console": "^2.7",
-                    "symfony/event-dispatcher": "^2.7",
-                    "symfony/options-resolver": "^2.7",
-                    "symfony/yaml": "^2.7",
-                    "tracy/tracy": "^2.3"
-                },
-                "autoload": {
-                  "psr-4": {
-                    "ApiGen\\": "src"
-                  }
-                },
-                "bin": [
-                  "bin/apigen"
-                ]
-            }
-        }
-    ]
+        "apigen/apigen": "4.1.1"
+    }
 }

--- a/templates/cakephp/404.latte
+++ b/templates/cakephp/404.latte
@@ -1,0 +1,23 @@
+{*
+ApiGen 3.0dev - API documentation generator for PHP 5.3+
+
+Copyright (c) 2010-2011 David Grudl (http://davidgrudl.com)
+Copyright (c) 2011-2012 Jaroslav Hanslík (https://github.com/kukulich)
+Copyright (c) 2011-2012 Ondřej Nešpor (https://github.com/Andrewsville)
+
+For the full copyright and license information, please view
+the file LICENSE.md that was distributed with this source code.
+*}
+{layout '@layout.latte'}
+{var $robots = false}
+
+{block #title}Page not found{/block}
+
+{block #content}
+<div id="content">
+	<h1>{include #title}</h1>
+	<p>The requested page could not be found.</p>
+	<p>You have probably clicked on a link that is outdated and points to a page that does not exist any more or you have made an typing error in the address.</p>
+	<p>To continue please try to find requested page in the menu,{if $config->tree} take a look at <a href="tree.html">the tree view</a> of the whole project{/if} or use search field on the top.</p>
+</div>
+{/block}

--- a/templates/cakephp/robots.txt.latte
+++ b/templates/cakephp/robots.txt.latte
@@ -1,0 +1,13 @@
+{*
+ApiGen 3.0dev - API documentation generator for PHP 5.3+
+
+Copyright (c) 2010-2011 David Grudl (http://davidgrudl.com)
+Copyright (c) 2011-2012 Jaroslav Hanslík (https://github.com/kukulich)
+Copyright (c) 2011-2012 Ondřej Nešpor (https://github.com/Andrewsville)
+
+For the full copyright and license information, please view
+the file LICENSE.md that was distributed with this source code.
+*}
+User-agent: *
+Disallow:
+Sitemap: {$config->baseUrl}/sitemap.xml

--- a/templates/cakephp/sitemap.xml.latte
+++ b/templates/cakephp/sitemap.xml.latte
@@ -1,0 +1,35 @@
+{*
+ApiGen 3.0dev - API documentation generator for PHP 5.3+
+
+Copyright (c) 2010-2011 David Grudl (http://davidgrudl.com)
+Copyright (c) 2011-2012 Jaroslav Hanslík (https://github.com/kukulich)
+Copyright (c) 2011-2012 Ondřej Nešpor (https://github.com/Andrewsville)
+
+For the full copyright and license information, please view
+the file LICENSE.md that was distributed with this source code.
+*}
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url>
+	<loc>{$config->baseUrl}/index.html</loc>
+</url>
+<url n:foreach="$namespaces as $namespace">
+	<loc>{$config->baseUrl}/{$namespace|namespaceUrl}</loc>
+</url>
+<url n:foreach="$packages as $package">
+	<loc>{$config->baseUrl}/{$package|packageUrl}</loc>
+</url>
+
+{define #elements}
+<url n:foreach="$elements as $element">
+	<loc>{$config->baseUrl}/{$element|elementUrl}</loc>
+</url>
+{/define}
+
+{include #elements, elements => $classes}
+{include #elements, elements => $interfaces}
+{include #elements, elements => $traits}
+{include #elements, elements => $exceptions}
+{include #elements, elements => $constants}
+{include #elements, elements => $functions}
+</urlset>


### PR DESCRIPTION
Upgrade to a recent tagged release of ApiGen and fix StringTemplate docs being skipped.

Refs #75 