### PR TITLE
Do not escape parameter description

### DIFF
--- a/templates/cakephp/function.latte
+++ b/templates/cakephp/function.latte
@@ -60,7 +60,7 @@ the file LICENSE.md that was distributed with this source code.
 			<td class="value"><code>{block|strip}
 				<var>{if $parameter->passedByReference}&amp; {/if}${$parameter->name}</var>{if $parameter->defaultValueAvailable} = {$parameter->defaultValueDefinition|highlightPHP:$function|noescape}{elseif $parameter->unlimited},…{/if}
 			{/block}</code></td>
-			<td>{$parameter->description|description:$function}</td>
+			<td>{$parameter->description|description:$function|noescape}</td>
 		</tr>
 		</table>
 	</div>


### PR DESCRIPTION
Remove HTML escaping on function's pages like https://api.cakephp.org/3.3/function-h.html

<img width="903" alt="capture d ecran 2017-01-30 a 06 35 19" src="https://cloud.githubusercontent.com/assets/4977112/22413228/4dd413c2-e6b6-11e6-8a90-cd2ac9a52a62.png">
