### PR TITLE
Latest version redirection

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -12,12 +12,12 @@ server {
         rewrite ^/$ https://api.cakephp.org/${cake3_latest}/ permanent;
     }
 
-    location ~ ^/3\.latest(/?.*)$ {
-        rewrite ^/3\.latest(/?.*)$ https://api.cakephp.org/${cake3_latest}$1 permanent;
+    location ~ ^/3\.(x|latest)(/?.*)$ {
+        rewrite ^/3\.(x|latest)(/?.*)$ https://api.cakephp.org/${cake3_latest}$2 permanent;
     }
 
-    location ~ ^/2\.latest(/?.*)$ {
-        rewrite ^/2\.latest(/?.*)$ https://api.cakephp.org/${cake2_latest}$1 permanent;
+    location ~ ^/2\.(x|latest)(/?.*)$ {
+        rewrite ^/2\.(x|latest)(/?.*)$ https://api.cakephp.org/${cake2_latest}$2 permanent;
     }
 
     location ~ ^/chronos/?$ {

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,12 +5,23 @@ server {
     index index.html index.;
     server_name _;
 
+    set $cake2_latest "2.9";
+    set $cake3_latest "3.4";
+
     location / {
-        rewrite ^/$ http://api.cakephp.org/3.4/ permanent;
+        rewrite ^/$ https://api.cakephp.org/${cake3_latest}/ permanent;
+    }
+
+    location ~ ^/3\.latest(/?.*)$ {
+        rewrite ^/3\.latest(/?.*)$ https://api.cakephp.org/${cake3_latest}$1 permanent;
+    }
+
+    location ~ ^/2\.latest(/?.*)$ {
+        rewrite ^/2\.latest(/?.*)$ https://api.cakephp.org/${cake2_latest}$1 permanent;
     }
 
     location ~ ^/chronos/?$ {
-        return 301 http://api.cakephp.org/chronos/1.0/;
+        return 301 https://api.cakephp.org/chronos/1.0/;
     }
 
     location ~ ^/1\.1(.*)$ {

--- a/nginx.conf
+++ b/nginx.conf
@@ -8,20 +8,20 @@ server {
     set $cake2_latest "2.9";
     set $cake3_latest "3.4";
 
-    location / {
-        rewrite ^/$ https://api.cakephp.org/${cake3_latest}/ permanent;
+    location ~ ^/$ {
+        return 303 https://api.cakephp.org/${cake3_latest}/;
     }
 
-    location ~ ^/3\.(x|latest)(/?.*)$ {
-        rewrite ^/3\.(x|latest)(/?.*)$ https://api.cakephp.org/${cake3_latest}$2 permanent;
+    location ~ ^/3\.(x|latest)/?(.*)$ {
+        return 303 https://api.cakephp.org/${cake3_latest}/$2;
     }
 
-    location ~ ^/2\.(x|latest)(/?.*)$ {
-        rewrite ^/2\.(x|latest)(/?.*)$ https://api.cakephp.org/${cake2_latest}$2 permanent;
+    location ~ ^/2\.(x|latest)/?(.*)$ {
+        return 303 https://api.cakephp.org/${cake2_latest}/$2;
     }
 
     location ~ ^/chronos/?$ {
-        return 301 https://api.cakephp.org/chronos/1.0/;
+        return 303 https://api.cakephp.org/chronos/1.0/;
     }
 
     location ~ ^/1\.1(.*)$ {


### PR DESCRIPTION
This PR is a proposal to prepare an alias URL to the latest version in the API document site. Please review.

## Problem to solve

Currently, when linking to an API document from a website or markdown Docs, you need to specify a URL containing a minor version.
Even if there is a version upgrade (eg 3.0 -> 3.1) the link will not change.

* eg. https://book.cakephp.org/3.0/en/views/helpers/url.html (At the bottom, the link "Router::url" is transferred to the API document of version 3.0) 
* eg. https://github.com/cakephp/datasource/blob/master/README.md (At the bottom, the link "official API documentation" is transferred to the API document of version 3.2) 

I thought that if you had an alias that always redirects to the latest API document when upgrading, documents will be easier to maintain.
At the same time I set the transfer link to https.

If redirecting automatically to the latest version is inconvenient, please dismiss this suggestion.

## How it works

When the latest version is 3.4 and 2.9

* https://api.cakephp.org/ -> https://api.cakephp.org/3.4/ (Same as current)
* https://api.cakephp.org/3.latest -> https://api.cakephp.org/3.4/
* https://api.cakephp.org/3.latest/ -> https://api.cakephp.org/3.4/ (It works even if there is a slash at the end of the URL)
* https://api.cakephp.org/2.latest -> https://api.cakephp.org/2.9/
* https://api.cakephp.org/3.latest/class-Cake.ORM.Table.html -> https://api.cakephp.org/3.4/class-Cake.ORM.Table.html (You can also redirect the URL of the sub directory content)
