### PR TITLE
increase readability for code blocks

### DIFF
--- a/templates/cakephp/resources/css/styles.css
+++ b/templates/cakephp/resources/css/styles.css
@@ -116,11 +116,11 @@ p,
 /* Preformatted text */
 code {
     font-family: "Roboto Mono", "Consolas", "Monaco", monospace;
-    font-size: 105%;
+    font-size: 100%;
     line-height: normal;
     padding: 0px 2px;
     color: #363637;
-    background: none;
+    background: #ECECE9;
 }
 
 /* lists */


### PR DESCRIPTION
before:


![old-api-style](https://user-images.githubusercontent.com/8215801/29253521-83123eb0-8094-11e7-93da-e465a5cd98c1.png)


now:


![new-api-style](https://user-images.githubusercontent.com/8215801/29253527-955df6b8-8094-11e7-9294-cac9145ea533.png)
