### PR TITLE
Add = and , to function signatures

### DIFF
--- a/templates/cakephp/class.latte
+++ b/templates/cakephp/class.latte
@@ -319,7 +319,7 @@ the file LICENSE.md that was distributed with this source code.
 					{$parameter->typeHint|typeLinks:$method|noescape}
 						<var>${$parameter->name}</var>
 					{if $parameter->defaultValueAvailable}
-						{$parameter->defaultValueDefinition|highlightPHP:$class|noescape}
+						= {$parameter->defaultValueDefinition|highlightPHP:$class|noescape}
 					{/if}
 					{if $parameter->unlimited},…{/if}{sep}, {/sep}
 				{/foreach}

--- a/templates/cakephp/function.latte
+++ b/templates/cakephp/function.latte
@@ -42,9 +42,9 @@ the file LICENSE.md that was distributed with this source code.
 				{$parameter->typeHint|typeLinks:$function|noescape}
 					<var>${$parameter->name}</var>
 				{if $parameter->defaultValueAvailable}
-					{$parameter->defaultValueDefinition|highlightPHP:$function|noescape}
+					= {$parameter->defaultValueDefinition|highlightPHP:$function|noescape}
 				{/if}
-				{if $parameter->unlimited},…{/if}
+				{if $parameter->unlimited},…{/if}{sep}, {/sep}
 			{/foreach}
 			)
 		{/block}


### PR DESCRIPTION
Currently functions missing `=` and `,`: `h( mixed $text boolean $double true string|null $charset null )` as signature.

Change to `h( mixed $text, boolean $double = true, string|null $charset = null )`.

https://api.cakephp.org/3.8/function-h.html
https://api.cakephp.org/3.8/class-Cake.Core.Configure.html#_read
