### PR TITLE
Version drop-down takes you to the same file

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,8 +9,12 @@ server {
     set $cake3_latest "3.8";
     set $chronos_latest "1.1";
 
-    location ~ ^/$ {
+    location = / {
         return 303 https://api.cakephp.org/${cake3_latest}/;
+    }
+
+    location ~ "^/([32]\.\d{1,2})/.*\.html$" {
+        try_files $uri @overview;
     }
 
     location ~ ^/3\.(x|latest)/?(.*)$ {
@@ -38,5 +42,10 @@ server {
         fastcgi_pass unix:/var/run/php5-fpm.sock;
         include fastcgi_params;
         try_files /rewrite.php foo.html;
+    }
+
+    location @overview {
+        rewrite "^/([32]\.\d{1,2})/.*$" /$1/ redirect;
+        return 404;
     }
 }

--- a/templates/cakephp/class.latte
+++ b/templates/cakephp/class.latte
@@ -10,6 +10,7 @@ the file LICENSE.md that was distributed with this source code.
 *}
 {layout '@layout.latte'}
 {var $active = 'class'}
+{capture $activeUrl}{$class|classUrl}{/capture}
 
 {block #title}{if $class->deprecated}Deprecated {/if}{if $class->interface}Interface{elseif $class->trait}Trait{else}Class{/if} {$class->name}{/block}
 

--- a/templates/cakephp/function.latte
+++ b/templates/cakephp/function.latte
@@ -10,6 +10,7 @@ the file LICENSE.md that was distributed with this source code.
 *}
 {layout '@layout.latte'}
 {var $active = 'function'}
+{capture $activeUrl}{$function|functionUrl}{/capture}
 
 {block #title}{if $function->deprecated}Deprecated {/if}Function {$function->name}{/block}
 

--- a/templates/cakephp/header.latte
+++ b/templates/cakephp/header.latte
@@ -123,7 +123,11 @@
 										</a>
 										<ul class="dropdown-menu">
 											{foreach $versions as $ver}
-												<li><a href="../{$ver}">{$ver}</a></li>
+												{if !empty($activeUrl)}
+													<li><a href="../{$ver}/{$activeUrl}">{$ver}</a></li>
+												{else}
+													<li><a href="../{$ver}">{$ver}</a></li>
+												{/if}
 											{/foreach}
 										</ul>
 									{/if}

--- a/templates/cakephp/namespace.latte
+++ b/templates/cakephp/namespace.latte
@@ -10,6 +10,7 @@ the file LICENSE.md that was distributed with this source code.
 *}
 {layout '@layout.latte'}
 {var $active = 'namespace'}
+{capture $activeUrl}{$namespace|namespaceUrl}{/capture}
 
 {block #title}{if $namespace != 'None'}Namespace {$namespace}{else}No namespace{/if}{/block}
 


### PR DESCRIPTION
@markstory https://github.com/cakephp/docs/issues/6153

I had an idea for this which seemed work out fairly well.

The version drop-down will take you to the same page if it exists.  If it doesn't exist, it will default to the overview page of the selected version.

This works for **namespaces**, **classes** and **functions**.  It does not work for source pages.