### PR TITLE
Exclude \Cake\Chronos\Traits namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           php-version: '7.4'
           extensions: mbstring, intl
+          tools: cs2pr
           coverage: none
 
       - name: Get composer cache directory
@@ -50,5 +51,5 @@ jobs:
         run: composer install
 
       - name: Run PHP CodeSniffer
-        run: vendor/bin/phpcs --report=checkstyle src/
+        run: vendor/bin/phpcs -q --report=checkstyle src/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,4 @@ jobs:
         run: composer install
 
       - name: Run PHP CodeSniffer
-        run: vendor/bin/phpcs -q --report=checkstyle src/
-
+        run: vendor/bin/phpcs -q --report=checkstyle src/ | cs2pr

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,10 @@
     "autoload": {
         "psr-4": {
             "Cake\\ApiDocs\\": "src/"
-        }
+        },
+        "files": [
+            "src/functions.php"
+        ]
     },
     "scripts": {
         "cs-check": "phpcs --colors --parallel=16 -p src/",

--- a/config/chronos.php
+++ b/config/chronos.php
@@ -8,6 +8,10 @@ return [
 
     'templatePath' => 'templates',
     'sourcePaths' => ['src'],
+    'excludes' => [
+        'namespaces' => ['\\Cake\\Chronos\\Traits'],
+        'names' => [],
+    ],
 
     'versions' => [
         '2.x' => '../2.x',

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -113,8 +113,11 @@ class Generator
     {
         $namespaces = $this->project->getProjectNamespaces();
         $renderNested = function ($loaded, $renderNested) use ($namespaces) {
-            $filename = 'namespace-' . str_replace('\\', '.', substr($loaded->fqsen, 1)) . '.html';
+            if (isExcluded($loaded->fqsen, true)) {
+                return;
+            }
 
+            $filename = 'namespace-' . str_replace('\\', '.', substr($loaded->fqsen, 1)) . '.html';
             $this->renderer->render(
                 'namespace.twig',
                 $filename,
@@ -141,9 +144,12 @@ class Generator
         $namespaces = $this->project->getProjectNamespaces();
         foreach ($this->project->getProjectFiles() as $file) {
             foreach ($file->file->getInterfaces() as $fqsen => $interface) {
+                if (isExcluded($fqsen, false)) {
+                    continue;
+                }
+
                 $loaded = $this->project->getLoader()->getInterface($fqsen);
                 $filename = 'interface-' . str_replace('\\', '.', substr($fqsen, 1)) . '.html';
-
                 $this->renderer->render(
                     'interface.twig',
                     $filename,
@@ -163,9 +169,12 @@ class Generator
         $namespaces = $this->project->getProjectNamespaces();
         foreach ($this->project->getProjectFiles() as $file) {
             foreach ($file->file->getClasses() as $fqsen => $class) {
+                if (isExcluded($fqsen, false)) {
+                    continue;
+                }
+
                 $loaded = $this->project->getLoader()->getClass($fqsen);
                 $filename = 'class-' . str_replace('\\', '.', substr($fqsen, 1)) . '.html';
-
                 $this->renderer->render(
                     'class.twig',
                     $filename,
@@ -185,9 +194,12 @@ class Generator
         $namespaces = $this->project->getProjectNamespaces();
         foreach ($this->project->getProjectFiles() as $file) {
             foreach ($file->file->getTraits() as $fqsen => $trait) {
+                if (isExcluded($fqsen, false)) {
+                    continue;
+                }
+
                 $loaded = $this->project->getLoader()->getTrait($fqsen);
                 $filename = 'trait-' . str_replace('\\', '.', substr($fqsen, 1)) . '.html';
-
                 $this->renderer->render(
                     'trait.twig',
                     $filename,
@@ -228,6 +240,10 @@ class Generator
         $search = [];
         foreach ($this->project->getProjectFiles() as $file) {
             foreach ($file->file->getInterfaces() as $interface) {
+                if (isExcluded((string)$interface->getFqsen(), false)) {
+                    continue;
+                }
+
                 foreach (array_keys($interface->getConstants()) as $fqsen) {
                     $search[] = ['i', substr($fqsen, 1)];
                 }
@@ -236,6 +252,10 @@ class Generator
                 }
             }
             foreach ($file->file->getClasses() as $class) {
+                if (isExcluded((string)$class->getFqsen(), false)) {
+                    continue;
+                }
+
                 foreach (array_keys($class->getConstants()) as $fqsen) {
                     $search[] = ['c', substr($fqsen, 1)];
                 }
@@ -247,6 +267,10 @@ class Generator
                 }
             }
             foreach ($file->file->getTraits() as $trait) {
+                if (isExcluded((string)$trait->getFqsen(), false)) {
+                    continue;
+                }
+
                 foreach (array_keys($trait->getProperties()) as $fqsen) {
                     $search[] = ['t', substr($fqsen, 1)];
                 }

--- a/src/Reflection/Project.php
+++ b/src/Reflection/Project.php
@@ -178,6 +178,10 @@ class Project
 
         $namespaces = [];
         foreach ($project->getNamespaces() as $fqsen => $namespace) {
+            if (in_array($fqsen, Configure::read('excludes.namespaces', []), true)) {
+                continue;
+            }
+
             $namespaces[$fqsen] = new LoadedNamespace($fqsen, $namespace);
             foreach (array_keys($namespace->getInterfaces()) as $interfaceFqsen) {
                 $namespaces[$fqsen]->interfaces[$interfaceFqsen] = $this->loader->getInterface($interfaceFqsen);

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+use Cake\Core\Configure;
+
+/**
+ * @param string $fqsen Fqsen to check if excluded
+ * @param bool $isNamespace Whether $fqsen is a namespace
+ * @return bool
+ */
+function isExcluded(string $fqsen, bool $isNamespace): bool
+{
+    $namespace = substr($fqsen, 0, strrpos($fqsen, '\\'));
+    if ($isNamespace) {
+        if (in_array($namespace, Configure::read('excludes.namespaces', []), true)) {
+            return true;
+        }
+
+        return in_array($fqsen, Configure::read('excludes.namespaces', []), true);
+    }
+
+    if (in_array($namespace, Configure::read('excludes.namespaces', []), true)) {
+        return true;
+    }
+
+    return in_array($fqsen, Configure::read('excludes.names', []), true);
+}


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp-api-docs/issues/157

This adds `excludes` config which controls which namespaces or names are excluded from the build.