### PR TITLE
Exclude cakephp implementation traits

### DIFF
--- a/config/cakephp.php
+++ b/config/cakephp.php
@@ -12,6 +12,8 @@ return [
         'namespaces' => [],
         'names' => [
             '\Cake\Collection\CollectionTrait',
+            '\Cake\Datasource\EntityTrait',
+            '\Cake\Datasource\QueryTrait',
             '\Cake\I18n\DateFormatTrait',
         ],
     ],

--- a/config/cakephp.php
+++ b/config/cakephp.php
@@ -8,6 +8,13 @@ return [
 
     'templatePath' => 'templates',
     'sourcePaths' => ['src', 'config'],
+    'excludes' => [
+        'namespaces' => [],
+        'names' => [
+            '\Cake\Collection\CollectionTrait',
+            '\Cake\I18n\DateFormatTrait',
+        ],
+    ],
 
     'versions' => [
         '4.2' => '../4.2/',

--- a/config/chronos.php
+++ b/config/chronos.php
@@ -9,7 +9,7 @@ return [
     'templatePath' => 'templates',
     'sourcePaths' => ['src'],
     'excludes' => [
-        'namespaces' => ['\\Cake\\Chronos\\Traits'],
+        'namespaces' => ['\Cake\Chronos\Traits'],
         'names' => [],
     ],
 


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp-api-docs/issues/144

Traits such as EntityTrait and QueryTrait are fully documented and usable outside of cakephp. It might not be useful to add them to the api docs though.