### PR TITLE
Render global as actual namespace.

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -17,8 +17,6 @@ declare(strict_types=1);
 
 namespace Cake\ApiDocs;
 
-use Cake\ApiDocs\Reflection\LoadedConstant;
-use Cake\ApiDocs\Reflection\LoadedFunction;
 use Cake\ApiDocs\Reflection\LoadedNamespace;
 use Cake\ApiDocs\Reflection\Project;
 use Cake\ApiDocs\Twig\TwigRenderer;
@@ -74,24 +72,11 @@ class Generator
      */
     public function renderOverview(): void
     {
-        $constants = [];
-        $functions = [];
-        foreach ($this->project->getProjectFiles() as $file) {
-            foreach ($file->file->getConstants() as $constant) {
-                $constants[$constant->getName()] = new LoadedConstant((string)$constant->getFqsen(), $constant, null);
-            }
-            foreach ($file->file->getFunctions() as $function) {
-                $functions[$function->getName()] = new LoadedFunction((string)$function->getFqsen(), $function);
-            }
-        }
-        ksort($constants);
-        ksort($functions);
-
         $namespaces = $this->project->getProjectNamespaces();
         $this->renderer->render(
             'overview.twig',
             'index.html',
-            ['constants' => $constants, 'functions' => $functions, 'namespaces' => $namespaces]
+            ['namespaces' => $namespaces]
         );
     }
 
@@ -105,7 +90,8 @@ class Generator
         $namespaces = $this->project->getProjectNamespaces();
         $renderNested = function ($loaded, $renderNested) use ($namespaces) {
             // Render namespace
-            $filename = 'namespace-' . str_replace('\\', '.', substr($loaded->fqsen, 1)) . '.html';
+            $path = $loaded->fqsen === '\\' ? 'Global' : str_replace('\\', '.', substr($loaded->fqsen, 1));
+            $filename = 'namespace-' . $path . '.html';
             $this->renderer->render(
                 'namespace.twig',
                 $filename,

--- a/src/Reflection/LoadedConstant.php
+++ b/src/Reflection/LoadedConstant.php
@@ -48,9 +48,9 @@ class LoadedConstant
     public DocBlock $docBlock;
 
     /**
-     * @var \Cake\ApiDocs\Reflection\LoadedClassLike|null
+     * @var \Cake\ApiDocs\Reflection\LoadedNamespace|\Cake\ApiDocs\Reflection\LoadedClassLike|null
      */
-    public ?LoadedClassLike $origin;
+    public $origin;
 
     /**
      * @var \Cake\ApiDocs\Reflection\LoadedInterface|null
@@ -60,9 +60,9 @@ class LoadedConstant
     /**
      * @param string $fqsen fqsen
      * @param \phpDocumentor\Reflection\Php\Constant $constant Reflection constant
-     * @param \Cake\ApiDocs\Reflection\LoadedClassLike|null $origin Origin loaded class-like
+     * @param \Cake\ApiDocs\Reflection\LoadedNamespace|\Cake\ApiDocs\Reflection\LoadedClassLike|null $origin Loaded origin
      */
-    public function __construct(string $fqsen, Constant $constant, ?LoadedClassLike $origin)
+    public function __construct(string $fqsen, Constant $constant, $origin)
     {
         $this->fqsen = $fqsen;
         $this->namespace = substr($this->fqsen, 0, strrpos($this->fqsen, '\\'));

--- a/src/Reflection/LoadedFunction.php
+++ b/src/Reflection/LoadedFunction.php
@@ -42,14 +42,21 @@ class LoadedFunction
     public Function_ $function;
 
     /**
+     * @var \Cake\ApiDocs\Reflection\LoadedNamespace|null
+     */
+    public ?LoadedNamespace $origin;
+
+    /**
      * @param string $fqsen fqsen
      * @param \phpDocumentor\Reflection\Php\Function_ $function Reflection function
+     * @param \Cake\ApiDocs\Reflection\LoadedNamespace|null $origin Loaded origin
      */
-    public function __construct(string $fqsen, Function_ $function)
+    public function __construct(string $fqsen, Function_ $function, ?LoadedNamespace $origin)
     {
         $this->fqsen = $fqsen;
         $this->namespace = substr($this->fqsen, 0, strrpos($this->fqsen, '\\'));
         $this->name = $function->getName();
         $this->function = $function;
+        $this->origin = $origin;
     }
 }

--- a/src/Reflection/LoadedNamespace.php
+++ b/src/Reflection/LoadedNamespace.php
@@ -32,6 +32,11 @@ class LoadedNamespace
     public string $namespace;
 
     /**
+     * @var string
+     */
+    public string $name;
+
+    /**
      * @var \phpDocumentor\Reflection\Php\Namespace_
      */
     public Namespace_ $element;
@@ -40,6 +45,16 @@ class LoadedNamespace
      * @var \Cake\ApiDocs\Reflection\LoadedNamespace[]
      */
     public array $children = [];
+
+    /**
+     * @var \Cake\ApiDocs\Reflection\LoadedConstant[]
+     */
+    public array $constants = [];
+
+    /**
+     * @var \Cake\ApiDocs\Reflection\LoadedFunction[]
+     */
+    public array $functions = [];
 
     /**
      * @var \Cake\ApiDocs\Reflection\LoadedInterface[]
@@ -64,6 +79,7 @@ class LoadedNamespace
     {
         $this->fqsen = $fqsen;
         $this->namespace = substr($this->fqsen, 0, strrpos($this->fqsen, '\\'));
+        $this->name = $element->getName() ? $element->getName() : 'Global';
         $this->element = $element;
     }
 }

--- a/src/Reflection/Project.php
+++ b/src/Reflection/Project.php
@@ -177,7 +177,29 @@ class Project
             $this->projectFiles[realpath($path)] = new LoadedFile($file, false);
         }
 
+        $this->loadGlobalNamespace($project);
         $this->loadNamespaces($project);
+    }
+
+    /**
+     * @param \phpDocumentor\Reflection\Php\Project $project Reflection project
+     * @return void
+     */
+    protected function loadGlobalNamespace(ReflectionProject $project): void
+    {
+        $root = new LoadedNamespace('\\', $project->getRootNamespace());
+        foreach ($project->getFiles() as $file) {
+            foreach ($file->getConstants() as $fqsen => $constant) {
+                $root->constants[$fqsen] = new LoadedConstant((string)$constant->getFqsen(), $constant, $root);
+            }
+            foreach ($file->getFunctions() as $fqsen => $function) {
+                $root->functions[$fqsen] = new LoadedFunction((string)$function->getFqsen(), $function, $root);
+            }
+        }
+        ksort($root->constants);
+        ksort($root->functions);
+
+        $this->projectNamespaces['\\Bla\\Blah'] = $root;
     }
 
     /**

--- a/src/Twig/Extension/ReflectionExtension.php
+++ b/src/Twig/Extension/ReflectionExtension.php
@@ -49,7 +49,11 @@ class ReflectionExtension extends AbstractExtension
                 return substr($fqsen, strrpos($fqsen, '\\') + 1);
             }),
             new TwigFilter('fqsen_to_url', function (string $fqsen, string $type) {
-                return sprintf('%s-%s.html', $type, preg_replace('[\\\\]', '.', substr($fqsen, 1)));
+                return sprintf(
+                    '%s-%s.html',
+                    $type,
+                    preg_replace('[\\\\]', '.', $fqsen === '\\' ? 'Global' : substr($fqsen, 1))
+                );
             }),
             new TwigFilter('docblock', function ($loaded) {
                 if ($loaded instanceof LoadedInterface) {

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -52,15 +52,11 @@
           <div id="groups">
             <h3 class="nav-title">Namespaces</h3>
             <ul class="nav-list">
-              {% set isGlobalActive = loaded is not defined %}
-              <li class="{{ isGlobalActive ? 'active' : '' }}">
-                <a href="index.html">Global</a>
-              </li>
               {% macro renderChildren(context, namespace, forceExpand) %}
                 {% set isActive = context.loaded ?? null is in_namespace(namespace.fqsen) %}
                 <li class="{{ isActive ? 'active' : '' }}">
-                  <a href="{{ namespace.fqsen|fqsen_to_url('namespace') }}">{{ namespace.fqsen|fqsen_to_name }}</a>
-                  {% if isActive or forceExpand %}
+                  <a href="{{ namespace.fqsen|fqsen_to_url('namespace') }}">{{ namespace.name }}</a>
+                  {% if isActive or forceExpand and namespace.children %}
                   <ul>
                     {% for child in namespace.children %}
                       {{ _self.renderChildren(context, child) }}

--- a/templates/namespace.twig
+++ b/templates/namespace.twig
@@ -1,10 +1,10 @@
 {% extends 'layout.twig' %}
 
-{% block title 'Namespace ' ~ loaded.fqsen|fqsen_to_name %}
+{% block title 'Namespace ' ~ loaded.name %}
 
 {% block content %}
 <div class="section namespace">
-  <h1>Namespace {{ loaded.fqsen|fqsen_to_name }}</h1>
+  <h1>Namespace {{ loaded.name }}</h1>
 
   {% if loaded.children is not empty %}
     <div>
@@ -14,6 +14,48 @@
         <li>
           <a href="{{ child.fqsen|fqsen_to_url('namespace') }}">{{ child.fqsen|fqsen_to_name }}</a>
         </li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
+  {% if loaded.functions is not empty %}
+    <div class="section">
+      <h2>Functions</h2>
+      <div class="method-detail">
+        {% for function in loaded.functions %}
+          <h3 class="method-name">
+            {{ function.name }}()
+
+            {% if function|docblock|get_tags('deprecated') is not empty %}
+              <span class="label">deprecated</span>
+            {% endif %}
+          </h3>
+
+          <pre><code class="language-php">{{ function.name }}(
+            {%- for argument in function.function.arguments %}
+              {{- function|docblock|param(argument.name).type ?? argument.type }} {% if argument.isVariadic %}...{% endif %}${{ argument.name }}{{ loop.last?'':', ' }}
+            {%- endfor -%}
+          )</code></pre>
+
+          <div class="description detailed">
+            {{ function|docblock.summary|markdown_to_html }}
+            {{ function|docblock.description|markdown_to_html }}
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
+
+  {% if loaded.constants is not empty %}
+    <div class="section">
+      <h2>Constants</h2>
+      <ul class="summary-list">
+        {% for constant in loaded.constants %}
+          <li>
+            {{ constant.name }}
+            {{ constant|docblock.summary|markdown_to_html }}
+          </li>
         {% endfor %}
       </ul>
     </div>

--- a/templates/overview.twig
+++ b/templates/overview.twig
@@ -4,48 +4,6 @@
 
 {% block content %}
 <div id="content">
-  <h1>{{ project }} {{ version }} Globals</h1>
-
-  {% if functions is not empty %}
-    <div class="section">
-      <h2>Global Functions</h2>
-      <div class="method-detail">
-        {% for function in functions %}
-          <h3 class="method-name">
-            {{ function.name }}()
-
-            {% if function|docblock|get_tags('deprecated') is not empty %}
-              <span class="label">deprecated</span>
-            {% endif %}
-          </h3>
-
-          <pre><code class="language-php">{{ function.name }}(
-            {%- for argument in function.function.arguments %}
-              {{- function|docblock|param(argument.name).type ?? argument.type }} {% if argument.isVariadic %}...{% endif %}${{ argument.name }}{{ loop.last?'':', ' }}
-            {%- endfor -%}
-          )</code></pre>
-
-          <div class="description detailed">
-            {{ function|docblock.summary|markdown_to_html }}
-            {{ function|docblock.description|markdown_to_html }}
-          </div>
-        {% endfor %}
-      </div>
-    </div>
-  {% endif %}
-
-  {% if constants is not empty %}
-    <div class="section">
-      <h2>Global Constants</h2>
-      <ul class="summary-list">
-        {% for constant in constants %}
-          <li>
-            {{ constant.name }}
-            {{ constant|docblock.summary|markdown_to_html }}
-          </li>
-        {% endfor %}
-      </ul>
-    </div>
-  {% endif %}
+  <h1>{{ project }} {{ version }} API Documentation</h1>
 </div>
 {% endblock %}


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp-api-docs/issues/161

This cleans out the index page for other things and makes the namespace rendering handle everything.
