### PR TITLE
Show full name for root level namespaces

### DIFF
--- a/src/Reflection/Project.php
+++ b/src/Reflection/Project.php
@@ -224,6 +224,7 @@ class Project
         // Create nested array
         foreach ($namespaces as $fqsen => $loaded) {
             if ($fqsen === Configure::read('namespace')) {
+                $loaded->name = substr($loaded->fqsen, 1);
                 $this->namespaces[$fqsen] = $loaded;
                 continue;
             }


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp-api-docs/issues/152