### PR TITLE
Support languages set from markdown

### DIFF
--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -36,7 +36,7 @@
   <script type="text/javascript" src="searchlist.js"></script>
   <script>
   $(document).ready(function () {
-    $('pre > code').addClass('language-php');
+    $('pre > code').not('[class |= language]').addClass('language-php');
   });
   </script>
 </head>


### PR DESCRIPTION
This prevents overriding an existing language class set from markdown.

@ADmad 