### PR TITLE
add github link to classlike template header

### DIFF
--- a/templates/pages/classlike.twig
+++ b/templates/pages/classlike.twig
@@ -11,6 +11,9 @@
     {% else %}
       {{ ref.name }}
     {% endif %}
+    {% if ref.source.inProject %}
+      <a href="{{ ref|node_to_repo_url }}" title="Permalink to Github" target="_blank"><i class="fa fa-github"></i></a>
+    {% endif %}
   </h1>
 
   <div class="description">


### PR DESCRIPTION
Adds the github link to that class in the header

![image](https://user-images.githubusercontent.com/9105243/169394580-23c1fb4d-429b-4a2c-a998-bae0814f0c37.png)
