### PR TITLE
fix github icon

### DIFF
--- a/templates/pages/classlike.twig
+++ b/templates/pages/classlike.twig
@@ -12,7 +12,7 @@
       {{ ref.name }}
     {% endif %}
     {% if ref.source.inProject %}
-      <a href="{{ ref|node_to_repo_url }}" title="Permalink to Github" target="_blank"><i class="fa fa-github"></i></a>
+      <a href="{{ ref|node_to_repo_url }}" title="Permalink to Github" target="_blank"><i class="fa-brands fa-github"></i></a>
     {% endif %}
   </h1>
 

--- a/templates/pages/parts/constant-detail.twig
+++ b/templates/pages/parts/constant-detail.twig
@@ -14,7 +14,7 @@
             <b>{{ constant.name }}</b>
             <a href="#{{ constant.name }}" class="permalink" title="Permalink to {{ constant.name }}">¶</a>
             {% if constant.source.inProject %}
-              <a href="{{ constant|node_to_repo_url }}" class="permalink" title="Permalink to Github" target="_blank"><i class="fa fa-github"></i></a>
+              <a href="{{ constant|node_to_repo_url }}" class="permalink" title="Permalink to Github" target="_blank"><i class="fa-brands fa-github"></i></a>
             {% endif %}
           </div>
 

--- a/templates/pages/parts/function-detail.twig
+++ b/templates/pages/parts/function-detail.twig
@@ -7,7 +7,7 @@
         {{ function.name }}()
         <a href="#{{ function.name }}()" class="permalink" title="Permalink to {{ function.name}}()">¶</a>
         {% if function.source.inProject %}
-          <a href="{{ function|node_to_repo_url }}" class="permalink" title="Permalink to Github" target="_blank"><i class="fa fa-github"></i></a>
+          <a href="{{ function|node_to_repo_url }}" class="permalink" title="Permalink to Github" target="_blank"><i class="fa-brands fa-github"></i></a>
         {% endif %}
 
         {% if function.abstract|default(false) %}

--- a/templates/pages/parts/property-detail.twig
+++ b/templates/pages/parts/property-detail.twig
@@ -7,7 +7,7 @@
         <var>${{ property.name }}</var>
         <a href="#${{ property.name }}" class="permalink" title="Permalink ${{ property.name }}">¶</a>
         {% if property.source.inProject %}
-          <a href="{{ property|node_to_repo_url }}" class="permalink" title="Permalink to Github" target="_blank"><i class="fa fa-github"></i></a>
+          <a href="{{ property|node_to_repo_url }}" class="permalink" title="Permalink to Github" target="_blank"><i class="fa-brands fa-github"></i></a>
         {% endif %}
 
         <span class="label">{{ property.visibility }}</span>


### PR DESCRIPTION
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/9105243/210399730-20bd3b17-18ea-42fc-a651-80e214359332.png">

Due to the recent change to FontAwesome 6 some (not all) icons need adjustment like `fa fa-github` is now `fa-brands fa-github`

I didn't find any other broken icons till now.